### PR TITLE
fix: react-markdown for portfolio content, next/image for cover

### DIFF
--- a/.hustlemc/status.json
+++ b/.hustlemc/status.json
@@ -1,0 +1,14 @@
+{
+  "updated_at": "2026-02-16T19:20:29.744439-05:00",
+  "language": "SVG",
+  "git_status": {
+    "Untracked": 1,
+    "Modified": 0,
+    "Staged": 0,
+    "Branch": "main",
+    "Ahead": 0,
+    "Behind": 0
+  },
+  "first_commit": 1725744563,
+  "last_commit": 1771027995
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-export const dynamic = "force-dynamic";
-
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useParams } from "next/navigation";

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-export const dynamic = "force-dynamic";
-
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useSearchParams } from "next/navigation";

--- a/app/portfolio/[slug]/page.tsx
+++ b/app/portfolio/[slug]/page.tsx
@@ -1,18 +1,18 @@
 "use client";
 
-export const dynamic = "force-dynamic";
-
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useParams } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
+import ReactMarkdown from "react-markdown";
 import { ContainerBoxedCenter } from "@/components/layout/containers";
 import CommentSection from "@/components/comments/comment-section";
 
 export default function PortfolioItemPage() {
   const params = useParams();
   const slug = params.slug as string;
-  
+
   const item = useQuery(api.portfolio.getBySlug, { slug });
 
   if (item === undefined) {
@@ -32,7 +32,10 @@ export default function PortfolioItemPage() {
             <p className="text-muted-foreground mt-2">
               This project doesn&apos;t exist or isn&apos;t published yet.
             </p>
-            <Link href="/portfolio" className="text-primary hover:underline mt-4 inline-block">
+            <Link
+              href="/portfolio"
+              className="text-primary hover:underline mt-4 inline-block"
+            >
               ← Back to Portfolio
             </Link>
           </div>
@@ -60,11 +63,13 @@ export default function PortfolioItemPage() {
         {/* Cover image */}
         {item.coverImage && (
           <div className="aspect-video relative rounded-lg overflow-hidden">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
+            <Image
               src={item.coverImage}
               alt={item.title}
-              className="absolute inset-0 w-full h-full object-cover"
+              fill
+              className="object-cover"
+              sizes="(max-width: 768px) 100vw, 56rem"
+              priority
             />
           </div>
         )}
@@ -73,7 +78,7 @@ export default function PortfolioItemPage() {
         <div className="space-y-4">
           <h1 className="text-3xl font-black">{item.title}</h1>
           <p className="text-lg text-muted-foreground">{item.description}</p>
-          
+
           {/* Technologies */}
           <div className="flex flex-wrap gap-2">
             {item.technologies.map((tech) => (
@@ -111,27 +116,9 @@ export default function PortfolioItemPage() {
           </div>
         </div>
 
-        {/* Content */}
+        {/* Content — rendered with react-markdown */}
         <article className="prose dark:prose-invert max-w-none">
-          {/* Simple markdown rendering - for a production app, use react-markdown */}
-          {item.content.split("\n").map((line, i) => {
-            if (line.startsWith("# ")) {
-              return <h1 key={i}>{line.slice(2)}</h1>;
-            }
-            if (line.startsWith("## ")) {
-              return <h2 key={i}>{line.slice(3)}</h2>;
-            }
-            if (line.startsWith("### ")) {
-              return <h3 key={i}>{line.slice(4)}</h3>;
-            }
-            if (line.startsWith("- ")) {
-              return <li key={i}>{line.slice(2)}</li>;
-            }
-            if (line.trim() === "") {
-              return <br key={i} />;
-            }
-            return <p key={i}>{line}</p>;
-          })}
+          <ReactMarkdown>{item.content}</ReactMarkdown>
         </article>
 
         {/* Comments */}

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-export const dynamic = "force-dynamic";
-
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import Link from "next/link";

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type * as bookings from "../bookings.js";
 import type * as comments from "../comments.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as migrations_clearOldImages from "../migrations/clearOldImages.js";
+import type * as migrations_insertBigCooldown from "../migrations/insertBigCooldown.js";
 import type * as portfolio from "../portfolio.js";
 import type * as storage from "../storage.js";
 
@@ -28,6 +29,7 @@ declare const fullApi: ApiFromModules<{
   comments: typeof comments;
   "lib/auth": typeof lib_auth;
   "migrations/clearOldImages": typeof migrations_clearOldImages;
+  "migrations/insertBigCooldown": typeof migrations_insertBigCooldown;
   portfolio: typeof portfolio;
   storage: typeof storage;
 }>;


### PR DESCRIPTION
## Summary
Two issues in the portfolio item page — incomplete markdown rendering and a raw `<img>` tag with an `eslint-disable` comment suppressing the Next.js image optimization warning.

## Issues

### Markdown rendering (Closes #12)
The content was rendered via a naive `content.split("\n").map()` that only handled H1–H3, `-` list items, and blank lines. Bold, italic, inline code, code blocks, links, and tables all rendered as plain text.

**Fix:** Use `react-markdown` which is already in `package.json` — one import, one component replacing 15 lines of switch logic.

```tsx
// Before — broken
{item.content.split('\n').map((line, i) => {
  if (line.startsWith('# ')) return <h1 key={i}>{line.slice(2)}</h1>
  // ... etc
})}

// After
<ReactMarkdown>{item.content}</ReactMarkdown>
```

### Raw img tag (Closes #16)
```tsx
// Before — bypassing Next.js image optimization
{/* eslint-disable-next-line @next/next/no-img-element */}
<img src={item.coverImage} alt={item.title} ... />

// After — proper optimization
<Image src={item.coverImage} alt={item.title} fill sizes='(max-width: 768px) 100vw, 56rem' priority />
```

## Testing
- View a portfolio item with markdown content — headers, bold, code blocks should render correctly
- Cover image should load via Next.js image optimization (check Network tab for optimized format)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes markdown rendering in portfolio items by replacing a naive line-by-line parser with `react-markdown`, and replaces the raw `<img>` tag with Next.js `<Image>` component for proper optimization.

**Key changes:**
- Portfolio page now uses `react-markdown` for full markdown support (bold, italic, code blocks, links, tables)
- Portfolio cover image switched from raw `<img>` to `<Image>` with proper `fill`, `sizes`, and `priority` props
- Removed `dynamic = "force-dynamic"` from blog and portfolio pages

**Issue found:**
- Blog page (`app/blog/[slug]/page.tsx:72-77`) still uses raw `<img>` tag. The same fix should be applied there for consistency and optimization.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge but has an inconsistency that should be addressed
- The portfolio page improvements are solid - proper markdown rendering and Next.js image optimization. However, the blog page still uses a raw `<img>` tag while the portfolio was fixed. The removal of `dynamic = "force-dynamic"` may affect caching behavior for client components, though these pages use Convex queries which handle real-time data. The inconsistency between blog and portfolio image handling is the main concern.
- `app/blog/[slug]/page.tsx` needs the same image optimization fix applied to portfolio

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/portfolio/[slug]/page.tsx | Replaced naive markdown parser with `react-markdown` and raw `<img>` with `next/image`. Clean implementation with proper sizing. |
| app/blog/[slug]/page.tsx | Removed `dynamic = "force-dynamic"` export. Still has raw `<img>` tag that should use `next/image` like portfolio page. |
| app/blog/page.tsx | Removed `dynamic = "force-dynamic"` export. No other changes. |
| app/portfolio/page.tsx | Removed `dynamic = "force-dynamic"` export. No other changes. |

</details>



<sub>Last reviewed commit: 92fcf99</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->