### PR TITLE
feat: add dynamic blog and portfolio routes to sitemap

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,11 +1,12 @@
 import type { MetadataRoute } from "next";
+import { fetchQuery } from "convex/nextjs";
+import { api } from "@/convex/_generated/api";
 
 const BASE_URL = "https://www.michaelchurley.com";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const lastModified = new Date();
 
-  // Static routes with their priorities and change frequencies
   const staticRoutes: MetadataRoute.Sitemap = [
     {
       url: BASE_URL,
@@ -33,18 +34,29 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
   ];
 
-  // Note: For dynamic routes (blog posts, portfolio items), 
-  // consider implementing a build-time data fetch or using 
-  // generateSitemaps() for larger sites with 50k+ URLs.
-  // 
-  // Example for dynamic content (requires API endpoint or build-time fetch):
-  // const blogPosts = await fetchBlogPosts();
-  // const blogRoutes = blogPosts.map((post) => ({
-  //   url: `${BASE_URL}/blog/${post.slug}`,
-  //   lastModified: new Date(post.updatedAt),
-  //   changeFrequency: "weekly" as const,
-  //   priority: 0.7,
-  // }));
+  try {
+    const [blogPosts, portfolioItems] = await Promise.all([
+      fetchQuery(api.blog.list, { onlyPublished: true }),
+      fetchQuery(api.portfolio.list, { onlyPublished: true }),
+    ]);
 
-  return [...staticRoutes];
+    const blogRoutes: MetadataRoute.Sitemap = blogPosts.map((post) => ({
+      url: `${BASE_URL}/blog/${post.slug}`,
+      lastModified: new Date(post.updatedAt),
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    }));
+
+    const portfolioRoutes: MetadataRoute.Sitemap = portfolioItems.map((item) => ({
+      url: `${BASE_URL}/portfolio/${item.slug}`,
+      lastModified: new Date(item.updatedAt),
+      changeFrequency: "monthly" as const,
+      priority: 0.6,
+    }));
+
+    return [...staticRoutes, ...blogRoutes, ...portfolioRoutes];
+  } catch (err) {
+    console.error("sitemap: failed to fetch dynamic routes", err);
+    return staticRoutes;
+  }
 }


### PR DESCRIPTION
## Summary
The sitemap was static-only — every blog post and portfolio item at `/blog/[slug]` and `/portfolio/[slug]` was invisible to search engines.

## Changes

### `app/sitemap.ts`
- Converted to `async` function (returns `Promise<MetadataRoute.Sitemap>`)
- Fetches published blog posts via `fetchQuery(api.blog.list, { onlyPublished: true })`
- Fetches published portfolio items via `fetchQuery(api.portfolio.list, { onlyPublished: true })`
- Generates `/blog/[slug]` entries with `updatedAt` as `lastModified`, priority `0.7`
- Generates `/portfolio/[slug]` entries with `updatedAt` as `lastModified`, priority `0.6`
- Graceful fallback: if Convex fetch fails, returns static routes only (logs error, never throws)

## Before / After
| Before | After |
|--------|-------|
| 4 static URLs | 4 static + N blog posts + M portfolio items |
| Blog posts not indexed | All published posts indexed with correct dates |
| Portfolio not indexed | All published items indexed with correct dates |

## Closes
Closes #10

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Converted static sitemap to dynamically include all published blog posts and portfolio items from Convex.

- Fetches blog and portfolio data in parallel using `Promise.all`
- Generates sitemap entries with proper `lastModified` dates from `updatedAt` field
- Includes appropriate priorities (0.7 for blog, 0.6 for portfolio)
- Gracefully falls back to static routes if Convex query fails
- Improves SEO discoverability for dynamic content

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks
- Clean implementation with proper async/await patterns, parallel fetching for efficiency, correct API usage matching Convex query signatures, and graceful error handling that prevents sitemap generation failures
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/sitemap.ts | Converted sitemap to async function that fetches published blog/portfolio items from Convex, with graceful fallback to static routes on error |

</details>



<sub>Last reviewed commit: fbef8d8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->